### PR TITLE
fix(): Close remote intf if conn request fails

### DIFF
--- a/internal/networkservice/xconnect/server.go
+++ b/internal/networkservice/xconnect/server.go
@@ -151,6 +151,10 @@ func (x *xconnectServer) Request(ctx context.Context, request *networkservice.Ne
 		// handleRemoteConnection().
 		err := handleRemoteConnection(ctx, srcConn, request, outgoing)
 		if err != nil {
+			_, errC := x.Close(ctx, srcConn)
+			if errC != nil {
+				logger.Errorf("Failed to close conn after request error: %v", errC)
+		        }
 			return nil, err
 		}
 		// If the connection was handled successfully, we need to store the dstMech. It is needed to cleanup the connection


### PR DESCRIPTION
If a remote connection request fails due to interface creation on the local node, the vxlan interface created on the remote node in the nse is not purged. Sending a Close() on the request chain to perform the deletion of the interface on the remote node.

Fixes https://avesha.atlassian.net/browse/AM-6692