### PR TITLE
fix(): Removed checking for authz policies in Close path

### DIFF
--- a/internal/networkservice/xconnect/server.go
+++ b/internal/networkservice/xconnect/server.go
@@ -190,6 +190,9 @@ func closeConnection(ctx context.Context, conn *networkservice.Connection) error
 		return nil
 	}
 	srcMech := conn.GetMechanism()
+	if srcMech == nil {
+		return nil
+	}
 
 	if srcMech.Cls == "LOCAL" && dstMech.Cls == "LOCAL" {
 		srcConn := conn.Clone()

--- a/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize/client.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize/client.go
@@ -94,9 +94,6 @@ func (a *authorizeClient) Close(ctx context.Context, conn *networkservice.Connec
 	if ok && p != nil {
 		ctx = peer.NewContext(ctx, p)
 	}
-	if err := a.policies.check(ctx, conn.GetPath()); err != nil {
-		return nil, err
-	}
 
 	return next.Client(ctx).Close(ctx, conn, opts...)
 }

--- a/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize/server.go
+++ b/vendor/github.com/networkservicemesh/sdk/pkg/networkservice/common/authorize/server.go
@@ -87,10 +87,6 @@ func (a *authorizeServer) Request(ctx context.Context, request *networkservice.N
 
 func (a *authorizeServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
 	var index = conn.GetPath().GetIndex()
-	var leftSide = &networkservice.Path{
-		Index:        index,
-		PathSegments: conn.GetPath().GetPathSegments()[:index+1],
-	}
 	if spiffeID, err := spire.SpiffeIDFromContext(ctx); err == nil {
 		connID := conn.GetPath().GetPathSegments()[index-1].GetId()
 		ids, ok := a.spiffeIDConnectionMap.Load(spiffeID)
@@ -108,11 +104,6 @@ func (a *authorizeServer) Close(ctx context.Context, conn *networkservice.Connec
 			a.spiffeIDConnectionMap.Delete(spiffeID)
 		} else {
 			a.spiffeIDConnectionMap.Store(spiffeID, ids)
-		}
-	}
-	if _, ok := peer.FromContext(ctx); ok {
-		if err := a.policies.check(ctx, leftSide); err != nil {
-			return nil, err
 		}
 	}
 	return next.Server(ctx).Close(ctx, conn)


### PR DESCRIPTION
Removed checking for authz policies when the connection is being closed. If the authz policy fails, the connection is never closed and attempts to close it continue forever.
Fixed a crash as well when accessing the source mechanism in the xconnect network service.