### PR TITLE
fix(): Handle NSC pods with no parent containers

### DIFF
--- a/internal/networkservice/mechanisms/recvfd/common.go
+++ b/internal/networkservice/mechanisms/recvfd/common.go
@@ -21,6 +21,7 @@ package recvfd
 import (
 	"context"
 	"net/url"
+	"os"
 	"sync"
 
 	"github.com/kubeslice/cmd-forwarder-kernel/internal/tools/fs"
@@ -53,8 +54,16 @@ func recvFDAndSwapInodeToFile(ctx context.Context, fileMap *perConnectionFileMap
 		return nil
 	}
 
+	fileNotPresentOnSystem := false
 	file, ok := fileMap.filesByInodeURL[inodeURLStr]
-	if !ok {
+	if ok {
+		// Check if the file is present
+		_, err := os.Stat(file)
+		if err != nil {
+			fileNotPresentOnSystem = true
+		}
+	}
+	if !ok || fileNotPresentOnSystem {
 		var err error
 		file, err = fs.GetNetnsFilePath(inodeURLStr)
 		if err != nil {


### PR DESCRIPTION
Some container runtimes might not have a parent container in kubernetes pods like the pause or the podman container. In such environments, the mapping between the network namespace inode to the pid of the parent container cannot be maintained. Instead, we end up using the pid of the nsc-init container in the mapping, but the map entry becomes invalid once the init container exits and the rest of the containers in the pod start up.
To fix this problem, we will rewrite the mapping with the pid of a regular container in the pod once the cmd-nsc sidecar starts up.